### PR TITLE
Fix: Correct unclosed AnimatedElement tag in Landing.tsx

### DIFF
--- a/src/components/Landing/Landing.tsx
+++ b/src/components/Landing/Landing.tsx
@@ -152,7 +152,7 @@ const Landing: React.FC = () => {
               </div>
               <button type="submit" className={styles.submitButton}>Send Message</button>
             </form>
-          </div>
+          </AnimatedElement> {/* Corrected closing tag */}
         </div>
       </section>
 

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 
-interface AuthContextType {
+export interface AuthContextType { // Added export
   isAuthenticated: boolean;
   user: any | null;
   login: (email: string, password: string) => Promise<void>;
@@ -8,7 +8,7 @@ interface AuthContextType {
   signup: (email: string, password: string) => Promise<void>;
 }
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
+export const AuthContext = createContext<AuthContextType | undefined>(undefined); // Added export
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);


### PR DESCRIPTION
This commit fixes a JSX syntax error in `src/components/Landing/Landing.tsx` where an `AnimatedElement` component wrapping the contact form was not properly closed. This error caused the Netlify build to fail.

The mismatched `</div>` tag has been replaced with the correct `</AnimatedElement>` closing tag.