### PR TITLE
Fix: Resolve ESLint errors causing build failure

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -83,7 +83,7 @@ const Header: React.FC<HeaderProps> = ({ pageType, navLinks, scrollToSection, is
       {pageType === 'landing' && navLinks && scrollToSection && (
         <nav className={`${styles.nav} ${styles.desktopNav}`}> {/* Add desktopNav class */}
           {navLinks.map(link => (
-            <a key={link.id} onClick={() => scrollToSection(link.id)}>
+            <a key={link.id} href="#" onClick={() => scrollToSection(link.id)}>
               {link.text}
             </a>
           ))}
@@ -94,7 +94,7 @@ const Header: React.FC<HeaderProps> = ({ pageType, navLinks, scrollToSection, is
       {pageType === 'landing' && isMobileMenuOpen && navLinks && scrollToSection && (
         <nav className={styles.mobileNav}>
           {navLinks.map(link => (
-            <a key={link.id} onClick={() => { scrollToSection(link.id); toggleMobileMenu(); }}>
+            <a key={link.id} href="#" onClick={() => { scrollToSection(link.id); toggleMobileMenu(); }}>
               {link.text}
             </a>
           ))}

--- a/src/components/Landing/About.tsx
+++ b/src/components/Landing/About.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import Footer from '../Common/Footer';
 import styles from './About.module.css';
 

--- a/src/hooks/useScrollAnimation.tsx
+++ b/src/hooks/useScrollAnimation.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 interface ScrollAnimationOptions extends IntersectionObserverInit {
   animationClass: string; // e.g., 'animate-fadeIn', 'animate-slideInUp'

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -1,4 +1,3 @@
-import apiClient from './apiClient';
 import { mockEvents } from '../mocks/events'; // Assuming mockEvents is already defined
 
 const simulateDelay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/services/malwareService.ts
+++ b/src/services/malwareService.ts
@@ -1,4 +1,3 @@
-import apiClient from './apiClient';
 import { mockMalwareData, MalwareEntry } from '../mocks/malware';
 
 const simulateDelay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
This commit addresses several ESLint errors that were preventing the Netlify build from completing successfully.

The following changes were made:

- `jsx-a11y/anchor-is-valid`: Added `href="#"` to anchor tags in `src/components/Header/Header.tsx` on lines 86 and 97. These links are used for intra-page navigation, and this change satisfies the accessibility rule.

- `@typescript-eslint/no-unused-vars`: Removed unused imports in the following files:
    - `Link` from `src/components/Landing/About.tsx`
    - `useState` from `src/hooks/useScrollAnimation.tsx`
    - `apiClient` from `src/services/eventService.ts`
    - `apiClient` from `src/services/malwareService.ts`

These changes ensure the codebase adheres to linting rules and allows the build process to complete without errors.